### PR TITLE
Watch task improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ gulp.task('watch', function () {
 });
 ```
 
+Also, there's an optional 3rd parameter to run a specific `gulp` processing first on changed files:
+
+```
+function runThisFirstOnChanged (files) {
+    return gulp.src(files).pipe(lint());
+}
+
+gulp.task('watch', fearCoreTasks.watch(['*.js'], ['test', 'build'], runThisFirstOnChanged));
+```
+
+In the above example, we run linting (only) on the changed files, then the defined tasks will run. If there's a linting error, the rest of the tasks will not run.
+
 ### Watching and linting files
 
 A core task is provided to watch a set of files and run linting on each saved file. This helps you to focus on a single file's linting issues.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,7 @@ gulp.task('lint', lint(all, true) );
 gulp.task('lint-all', lint(all, false) );
 gulp.task('lint-report', lintReport(all) );
 
-gulp.task('test', ['lint'], function () {
+gulp.task('test', function () {
     return gulp.src(specs, { read: false })
         .pipe(mocha({
             reporter: 'spec'
@@ -24,7 +24,7 @@ gulp.task('test', ['lint'], function () {
 });
 
 gulp.task('watch', function() {
-    watch(all, lintOnChange, ['test']);
+    watch(all, ['test'], lintOnChange);
 });
 
 gulp.task('watch-and-lint', watchAndLintOnChange(all));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@
 var gulp = require('gulp');
 var mocha = require('gulp-mocha');
 var lint = require('./index').lintJavascript;
+var lintOnChange = require('./index').lintOnChange;
 var lintReport = require('./index').lintReport;
 var watch = require('./index').watch;
 var watchAndLintOnChange = require('./index').watchAndLintOnChange;
@@ -23,7 +24,7 @@ gulp.task('test', ['lint'], function () {
 });
 
 gulp.task('watch', function() {
-    watch(all, ['test']);
+    watch(all, lintOnChange, ['test']);
 });
 
 gulp.task('watch-and-lint', watchAndLintOnChange(all));

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
     lintJavascript: require('./tasks/eslint/details'),
+    lintOnChange: require('./tasks/eslint/on-change'),
     lintReport: require('./tasks/eslint/report'),
     startKarmaServer: require('./tasks/start-karma-server'),
     startKarmaRunner: require('./tasks/start-karma-runner'),

--- a/tasks/eslint/on-change.js
+++ b/tasks/eslint/on-change.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var gulp = require('gulp');
+var gutil = require('gulp-util');
+var eslint = require('gulp-eslint');
+
+function fileReport (results) {
+    var passed = results[0].errorCount === 0 && results[0].warningCount === 0;
+    if (passed) {
+        gutil.log('linting ' + gutil.colors.green('OK'), results[0].filePath);
+    }
+}
+
+module.exports = function lintChanged (files) {
+    return gulp.src(files)
+        .pipe(eslint())
+        .pipe(eslint.format(fileReport))
+        .pipe(eslint.format())
+        .pipe(eslint.failOnError());
+};

--- a/tasks/watch-and-lint-on-change.js
+++ b/tasks/watch-and-lint-on-change.js
@@ -1,28 +1,10 @@
 'use strict';
 
-var gulp = require('gulp');
-var gutil = require('gulp-util');
-var eslint = require('gulp-eslint');
-
-function lint (file) {
-    gulp.src([file.path])
-        .pipe(eslint())
-        .pipe(eslint.format(fileReport))
-        .pipe(eslint.format());
-}
-
-function fileReport (results) {
-    var isError = results[0].errorCount > 0;
-    var file = results[0].filePath;
-    if (isError) {
-        gutil.log('linting ' + gutil.colors.red('error'));
-    } else {
-        gutil.log('linting ' + gutil.colors.green('OK'), file);
-    }
-}
+var watch = require('./watch');
+var lintOnChange = require('./eslint/on-change');
 
 module.exports = function taskFactory (src) {
     return function task () {
-        gulp.watch(src).on('change', lint);
+        watch(src, lintOnChange, []);
     };
 };

--- a/tasks/watch-and-lint-on-change.js
+++ b/tasks/watch-and-lint-on-change.js
@@ -5,6 +5,6 @@ var lintOnChange = require('./eslint/on-change');
 
 module.exports = function taskFactory (src) {
     return function task () {
-        watch(src, lintOnChange, []);
+        watch(src, [], lintOnChange);
     };
 };

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -5,7 +5,7 @@ var watch = require('gulp-watch');
 var batch = require('gulp-batch');
 var runSequence = require('run-sequence');
 
-module.exports = function taskFactory (src, runOnChanged, tasks) {
+module.exports = function taskFactory (src, tasks, runFirstOnChanged) {
 
     watch(src, { verbose: true }, batch(function (events, done) {
 
@@ -14,11 +14,14 @@ module.exports = function taskFactory (src, runOnChanged, tasks) {
             files.push(file.path);
         });
 
-        gulp.task('run-on-changed-files', function () {
-            return runOnChanged(files);
-        });
+        var all = tasks.concat([ done ]);
 
-        var all = ['run-on-changed-files'].concat(tasks.concat([ done ]));
+        if (typeof runFirstOnChanged === 'function') {
+            gulp.task('run-on-changed-files-first', function () {
+                return runFirstOnChanged(files);
+            });
+            all = ['run-on-changed-files-first'].concat(all);
+        }
 
         runSequence.use(gulp);
         runSequence.apply(null, all);

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -5,11 +5,23 @@ var watch = require('gulp-watch');
 var batch = require('gulp-batch');
 var runSequence = require('run-sequence');
 
-module.exports = function taskFactory (src, tasks) {
+module.exports = function taskFactory (src, runOnChanged, tasks) {
 
-    watch(src, batch(function (events, done) {
+    watch(src, { verbose: true }, batch(function (events, done) {
+
+        var files = [];
+        events._list.forEach(function (file) {
+            files.push(file.path);
+        });
+
+        gulp.task('run-on-changed-files', function () {
+            return runOnChanged(files);
+        });
+
+        var all = ['run-on-changed-files'].concat(tasks.concat([ done ]));
+
         runSequence.use(gulp);
-        runSequence.apply(null, tasks.concat([ done ]));
+        runSequence.apply(null, all);
     }));
 
 };


### PR DESCRIPTION
new API method: `lintOnChange`

watching files with `gulp-watch` instead of the built-in `watch` method of `gulp`, which is a more efficient, responsive and cross-OS solution